### PR TITLE
Fix: Resolve 500 error in solution verification

### DIFF
--- a/backend/routes/room.js
+++ b/backend/routes/room.js
@@ -254,14 +254,13 @@ router.post('/verify', auth, async (req, res) => {
     try {
       const roomDocForUpdate = await Room.findOne({ roomId });
       if (roomDocForUpdate) {
-        const dbScores = typeof roomDocForUpdate.scores === 'object' && roomDocForUpdate.scores ? { ...roomDocForUpdate.scores } : {};
-        dbScores[user.username] = state.scores[user.username];
-        roomDocForUpdate.scores = dbScores;
-        // DO NOT clear currentProblem here; leave it until next problem assigned or contest ends
+        roomDocForUpdate.scores.set(user.username, state.scores[user.username]);
         await roomDocForUpdate.save();
       }
     } catch (dbErr) {
       console.error('Failed to persist scores to DB for room', roomId, dbErr);
+      // This is a non-critical error, so we don't send a 500 response.
+      // The in-memory state is correct, so the contest can continue.
     }
 
     // Notify clients


### PR DESCRIPTION
This commit resolves a 500 Internal Server Error in the `/api/rooms/verify` endpoint by fixing two distinct bugs.

The first bug was an uninitialized `roomState` object, which caused a `TypeError` when the verification process was initiated. This is resolved by initializing `roomState` as a `Map` in `backend/index.js` and managing its state in the `/create` and `/join` routes.

The second bug occurred during the database update after a successful verification. The code was attempting to update a Mongoose Map field with a plain JavaScript object, causing an exception during the `.save()` operation. This is fixed by using the correct `.set()` method to update the user's score in the database.

These two fixes together ensure the stability and correctness of the solution verification process.